### PR TITLE
Add RFC 019 - Enhance revision  model to include release notes

### DIFF
--- a/text/019-revision-notes.md
+++ b/text/019-revision-notes.md
@@ -1,0 +1,28 @@
+# RFC 19: Release Notes on Revisions
+
+* RFC: 19
+* Author: Edward Henderson
+* Status: Draft
+* Created: 2018-03-29
+* Last Modified: 2018-03-29
+
+## Abstract
+
+Enhance the revision system to allow release notes to be added when publishing.
+
+## Specification
+
+The current revision system is great, but does not offer a way to provide release
+notes for a revision. This RFC proposes that the mechanism be expanded to allow a custom release model to be used for a page, and a way to override the publish dialog to support addition of release notes.
+
+
+## Open Questions
+
+### Should revision history be collected for Draft revisions?
+
+I would suggest not
+
+### Should this enhancement replace current functionality?
+
+I do not know the details of how the revision model is managed by the Page model, but if possible this feature should be implemented as a way to enhance the existing model, most likely by specifying a different revision model to use, and allowing the developer to enhance this base model with one that accepts release notes.
+


### PR DESCRIPTION
Adding an RFC on a request to enhance the current revision system to include an optional ability to replace the current model with one that includes release notes.

