### PR TITLE
[#61] Note obsolete PRs rather than deleting them

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ bit of a design process and produce a consensus among the Wagtail core team.
 The "RFC" (request for comments) process is intended to provide a consistent
 and controlled path for new features to enter the CMS.
 
-[Active RFC List](https://github.com/wagtail/rfcs/pulls)
+Current RFCs:
+- [Active](https://github.com/wagtail/rfcs/pulls?q=is%3Apr+label%3AActive+)
+- [Proposed](https://github.com/wagtail/rfcs/pulls?q=is%3Aopen+is%3Apr+label%3AProposed)
 
 ## When you should follow this process
 

--- a/text/010-search-query-classes.md
+++ b/text/010-search-query-classes.md
@@ -1,4 +1,4 @@
-# RFC 10: Search query classes
+# RFC 10: Search query classes (superseded by [RFC 25](025-search-query-classes-revised.md))
 
 * RFC: 10
 * Author: Karl Hobley

--- a/text/011-revisions-api.md
+++ b/text/011-revisions-api.md
@@ -1,0 +1,136 @@
+# RFC 11: Revisions Admin API
+
+* RFC: 11
+* Author: Karl Hobley
+* Created: 2016-07-18
+* Last Modified: 2016-07-31
+
+## Abstract
+
+Currently, the Admin API can only access the live version of a page's content.
+In order to support page editing, we must allow the admin API to access the
+latest draft and also create new revisions and publish them.
+
+I also think that the revisions UI currently in Wagtail would be better
+implemented using the admin API as this would allow us to implement it in a
+way that doesn't require the user to navigate away from the editor.
+
+This RFC proposes an extension to the Admin API to allow page revisions to be
+retrieved and created.
+
+## Specification
+
+### Data format
+
+All of the responses return revisions in the following format
+
+```json
+
+    {
+        "id": 1,
+        "created_at": "2016-07-18T16:37:00+01:00",
+        "author": "karl",
+        "in_moderation": false,
+        "content": {
+            "title": "Home",
+            "body": "foo"
+        }
+   }
+```
+
+### URL structure
+
+We will add a new endpoint underneath the pages endpoint allowing access to
+revisions of specific pages.
+
+#### View all revisions of a page
+
+This will be paginated to show up to 20 revisions at a time.
+
+    GET /api/pages/revisions/?page_id=1
+
+The list will be formatted the same way as other listings in the API:
+
+```json
+
+    {
+        "meta": {
+            "total_count": 50,
+        },
+        "items": [
+            # Revisions here
+        ]
+    }
+```
+
+##### Filter by date/time range
+
+Date or date/time in ISO8601 format. If a date is specified, both ends of the
+range are inclusive (equivalent to Django's __gte and __lte queries)
+
+The start and end times are separated by three dots: '...'. One end of the
+range may be omitted making that end unbounded.
+
+    GET /api/pages/revisions/?page_id=1&created_at=2016-07-18...
+    GET /api/pages/revisions/?page_id=1&created_at=...2016-07-18
+    GET /api/pages/revisions/?page_id=1&created_at=2016-01-01...2016-07-18
+    GET /api/pages/revisions/?page_id=1&created_at=2016-07-18T16:37:00+01:00...
+
+##### Filter by author
+
+Filters by the value of the ``USERNAME_FIELD`` on the user model
+
+    GET /api/pages/revisions/?page_id=1&author=karl
+
+#### View a particular revision
+
+##### By ID
+
+    GET /api/pages/revisions/123/
+
+##### By earliest/latest created at date
+
+Like the rest of the API, the revisions API also supports sorting/limiting
+which allows fetching the latest/earliest revisions.
+
+    GET /api/pages/revisions/?page_id=1&order=-created_at&limit=1  (latest)
+    GET /api/pages/revisions/?page_id=1&order=created_at&limit=1   (earliest)
+
+
+#### Create a new revision (edit a page)
+
+Creating a new revision is done by submitting the value of the "content" field
+as a JSON dictionary to the following URL
+
+    POST /api/pages/revisions/?page_id=1
+
+##### Submit for moderation
+
+Saves and submits the new revision for moderation
+
+    POST /api/pages/revisions/?submit_for_moderation=true
+
+##### Publish
+
+Saves and publishes the new revision
+
+    POST /api/pages/revisions/?page_id=1&publish=true
+
+##### Safeguarding against double-edit
+
+Double editing can be implemented by sending the previous revision id to the
+server on save. If there is a more recent revision that has already been
+committed to the server, the revision being submitted would be rejected.
+
+    POST /api/pages/revisions/?page_id=1&if_current_revision_id=1
+
+Note that this doesn't mean that the user is told they must refresh the page
+and lose their changes. It may even be possible to resolve conflicts manually
+by retrieving the latest revision and merging the two. This process is out of
+scope for this RFC though.
+
+##### Locked pages
+
+A page cannot be edited in any way if it is locked, so attempting to create a
+new revision for a locked page will result in a ``423 Locked`` response code
+and the new revision will not be saved.

--- a/text/011-revisions-api.md
+++ b/text/011-revisions-api.md
@@ -1,4 +1,4 @@
-# RFC 11: Revisions Admin API
+# RFC 11: Revisions Admin API (superseded by [RFC 15](015-revisions-api-revised.md))
 
 * RFC: 11
 * Author: Karl Hobley

--- a/text/015-revisions-api-revised.md
+++ b/text/015-revisions-api-revised.md
@@ -7,7 +7,7 @@
 
 ## Abstract
 
-This RFC 15 is an updated version of the `RFC 11 <#11>` by Karl Hobley.
+This RFC 15 is an updated version of the [RFC 11](011-revisions-api.md) by Karl Hobley.
 It was created to allow more time for discussing the new Admin API and
 has some parts copied from the original RFC 11.
 
@@ -23,7 +23,7 @@ This RFC proposes an extension to the Admin API to allow page revisions to be
 retrieved and created.
 
 Some of the changes are inspired by the
-`Google Drive API <https://developers.google.com/drive/v3/reference/revisions>`_.
+[Google Drive API](https://developers.google.com/drive/v3/reference/revisions).
 
 ## Specification
 

--- a/text/025-search-query-classes-revised.md
+++ b/text/025-search-query-classes-revised.md
@@ -7,7 +7,7 @@
 
 ## Abstract
 
-In RFC 10 we introduced the idea of "Search Query Classes", a way to allow
+In [RFC 10](010-search-query-classes.md) we introduced the idea of "Search Query Classes", a way to allow
 Wagtail to support more complex querying methods.
 
 This RFC replaces that previous RFC.

--- a/text/029-immutable-revision-events.md
+++ b/text/029-immutable-revision-events.md
@@ -1,0 +1,12 @@
+# RFC 29: Immutable Revision Events (deleted)
+
+* RFC: 29
+* Authors: Andy Chosak, Ryan Verner, and David Prothero
+* Created: 2018-06-15
+* Last Modified: 2018-06-15
+
+## Status
+
+Deleted 2020-07-20 in [#55](https://github.com/wagtail/rfcs/pull/55)
+
+Text can be found in [#29](https://github.com/wagtail/rfcs/pull/29)


### PR DESCRIPTION
Closes #61

- Restore text of RFC 11
- Add notes about deletion and supersession to RFCs #10, #11, #29 (restored file for 29)
- Make links functional in RFCs #15 and #25
- Update links to RFCs in README to use "Active" and "Proposed" labels (which I just made, and which make it easier to browse the PRs by sorting out PRs like this one which aren't RFCs)