### PR TITLE
Improve links to open and active RFCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,14 @@ bit of a design process and produce a consensus among the Wagtail core team.
 The "RFC" (request for comments) process is intended to provide a consistent
 and controlled path for new features to enter the CMS.
 
-Current RFCs:
-- [Active](https://github.com/wagtail/rfcs/pulls?q=is%3Apr+label%3AActive+)
-- [Proposed](https://github.com/wagtail/rfcs/pulls?q=is%3Aopen+is%3Apr+label%3AProposed)
+**Open RFCs (proposed new features):**
+- [New](https://github.com/wagtail/rfcs/pulls?q=is%3Apr+is%3Aopen+label%3A1%3ANew)
+- [Accepted](https://github.com/wagtail/rfcs/pulls?q=is%3Apr+is%3Aopen+label%3A2%3AAccepted)
+- [Review](https://github.com/wagtail/rfcs/pulls?q=is%3Apr+is%3Aopen+label%3A3%3AReview)
+- [Final Comment Period](https://github.com/wagtail/rfcs/pulls?q=is%3Apr+is%3Aopen+label%3A%224%3AFinal+Comment+Period%22)
+
+**Active RFCs (awaiting implementation):**
+- https://github.com/wagtail/rfcs/tree/main/text
 
 ## When you should follow this process
 


### PR DESCRIPTION
This change updates the README to improve the links to RFCs. We haven't been consistently using the "Proposed" and "Active" GitHub labels and so the current links don't provide a good overview of what RFCs are still under discussion
and which ones have been accepted by the core team and are awaiting implementation.