### PR TITLE
RFC 84: Public roadmap updates

### DIFF
--- a/text/084-2023-roadmap.md
+++ b/text/084-2023-roadmap.md
@@ -27,7 +27,7 @@ The core team review should include:
 - Discussions at one or two core team meetings to find reviewers or discuss specific points.
 - Approval by enough core team members to reach a consensus.
 
-Like all RFCs, feedback from the wider community is welcome but not required.
+Like all RFCs, feedback from the wider community is also welcome.
 
 ### Level of detail
 

--- a/text/084-2023-roadmap.md
+++ b/text/084-2023-roadmap.md
@@ -147,15 +147,17 @@ See [RFC 72: Background workers #72](https://github.com/wagtail/rfcs/pull/72)
 
 ### Search improvements
 
+Follow-up to earlier consolidation of search functionality.
+
 - Move search into separate package
 - New search back-end
 - Better docs/APIs for third-parties
 
-### RTL support
+### RTL languages support
 
 See [Supporting RTL languages](https://github.com/wagtail/wagtail/discussions/7793).
 
-### Image optimisation
+### Image optimisations
 
 Improvements to reduce the weight of images generated with Wagtail, that will be relevant for all sites with little to no rework.
 

--- a/text/084-2023-roadmap.md
+++ b/text/084-2023-roadmap.md
@@ -81,7 +81,6 @@ Consolidating our approach to permissions so code is easier to maintain.
 - Easier menu items organisation for snippets (register outside the "Snippets" menu)
 - Custom icons for snippets
 - Easier filtering setup for snippets listing
-- Cover ModelAdmin features, deprecate ModelAdmin
 
 ### SVG support
 

--- a/text/084-2023-roadmap.md
+++ b/text/084-2023-roadmap.md
@@ -1,0 +1,192 @@
+# RFC 084: Public roadmap updates
+
+- RFC: 084
+- Author: Thibaud Colas
+- Created: 2023-02-27
+- Last Modified: 2023-02-27
+
+## Abstract
+
+With Wagtail’s [public roadmap](https://github.com/wagtail/roadmap) now in place, we need to update it to reflect planned changes for future releases. This RFC provides a high-level overview of proposed roadmap items for the next three releases, and a proposed process to review roadmap additions.
+
+[RFC 79: Public roadmap](https://github.com/wagtail/rfcs/blob/main/text/079-roadmap.md) defines the contents of the roadmap have to be considered by the core team, but doesn’t specify further how this process works. We can trial running this via RFCs, and update our [roadmap governance documentation](https://github.com/wagtail/roadmap/blob/main/README.md) accordingly if successful.
+
+## Proposed review process
+
+RFCs can be used for roadmap additions, so core team members and the wider community can provide feedback easily. Using an RFC isn’t mandatory as long as additions still get duly reviewed by the core team. This process will be documented within our [guide to the roadmap](https://github.com/wagtail/roadmap#guide-to-the-roadmap).
+
+The review process can be used to:
+
+- Make sure the level of detail is appropriate for the roadmap (see below).
+- Propose changes to specific roadmap items.
+- Assess whether a given addition is likely to require an RFC or not.
+
+The core team review should include:
+
+- Sharing the proposed additions on regular core team channels.
+- Discussions at one or two core team meetings to find reviewers or discuss specific points.
+- Approval by enough core team members to reach a consensus.
+
+Like all RFCs, feedback from the wider community is welcome but not required.
+
+### Level of detail
+
+Proposed roadmap items should provide enough details to fill in the relevant sections of this proposed roadmap item template:
+
+```markdown
+## Summary
+
+A short overview of the proposed work. One paragraph, tweet-sized.
+
+## Intended Outcome
+
+A short paragraph or list of 2-5 items detailing what will be the result of this work.
+
+## More information
+
+If relevant – a list of 1-3 links to related issues, pull requests, RFCs, or other documentation.
+```
+
+Usage of the template as-is isn’t mandatory. For example, if an item is already tracked by a given issue / pull request / or RFC with sufficient details – that can be used as-is.
+
+### Review timeline
+
+It helps with planning of a release if roadmap items are reviewed ahead of development starting for said release. Our process should fit between a major/minor release’s first release candidate (RC) and the final release (as defined by our [release schedule](https://github.com/wagtail/wagtail/wiki/release-schedule)).
+
+For example, if Wagtail 4.2’s first RC is released on Friday 20th Jan, and its final release is on Monday 6th Feb, roadmap additions can be reviewed for two weeks between Monday 23rd Jan and Monday 6th Feb, including potential discussions at two core team meetings. This means the RFC will spend 3 days in its "Review" stage and 10 days in "Final Comment Period".
+
+To keep the review process fast, we recommend to:
+
+- Avoid making more additions to a list of roadmap items proposed as an RFC after the initial RFC submissions.
+- Remove proposed roadmap items which prove too complex to review with this process. They can be reviewed separately as appropriate.
+
+## Proposed items scheduled for Wagtail 5.0 (May 2023)
+
+### Permissions consolidation
+
+Consolidating our approach to permissions so code is easier to maintain.
+
+- Consistent permission model
+- Single approach for permissions (tech debt/performance as we can then introduce better caching in one place)
+- page choose permission
+
+### Search consolidation
+
+- Fix search autocomplete
+- Fix search boosting
+
+### Snippets enhancements
+
+- Tracking deletion/unpublishing of objects used on published pages (big snippets gap)
+- Easier menu items organisation for snippets (register outside the "Snippets" menu)
+- Custom icons for snippets
+- Easier filtering setup for snippets listing
+- Cover ModelAdmin features, deprecate ModelAdmin
+
+### SVG support
+
+See [RFC 77: Support for SVG images](https://github.com/wagtail/rfcs/pull/77), pull request [#9842](https://github.com/wagtail/wagtail/pull/9842), and [Support for SVG images #1708](https://github.com/wagtail/wagtail/issues/1708).
+
+### Accessibility checker enhancements
+
+Follow-up to Wagtail 4.2’s [new accessibility checker](https://wagtail.org/blog/introducing-wagtails-new-accessibility-checker/).
+
+Proposed additions:
+
+- [Sorting accessibility checker results based on their order on the page #10013](https://github.com/wagtail/wagtail/issues/10013)
+- [Highlight elements with errors in accessibility checker (outline) #10138](https://github.com/wagtail/wagtail/issues/10138)
+- [Keyboard support improvements in accessibility checker #10135](https://github.com/wagtail/wagtail/issues/10135)
+- [Support custom configuration options in accessibility checker #10137](https://github.com/wagtail/wagtail/issues/10137)
+- (Stretch) [Integrate accessibility checker within the page editor #10136](https://github.com/wagtail/wagtail/issues/10136)
+
+### Icons revamp
+
+See:
+
+- [Phase out icon font and use SVG everywhere #6107](https://github.com/wagtail/wagtail/issues/6107)
+- [Wagtail icon set should be extended and improved #2349](https://github.com/wagtail/wagtail/issues/2349)
+
+### Page editor UX refinements
+
+See:
+
+- [Field and block UI hierarchy #9945](https://github.com/wagtail/wagtail/issues/9945)
+- [Page editor minimap UI refinements #10055](https://github.com/wagtail/wagtail/issues/10055)
+- Other more minor UX changes based on design review ([Wagtail 3.x-4.x editor experience feedback #9553](https://github.com/wagtail/wagtail/discussions/9553))
+
+### Admin dark theme
+
+See [Dark theme for the admin interface #10056](https://github.com/wagtail/wagtail/issues/10056)
+
+### Sustainability considerations for Wagtail sites
+
+R&D and documentation programme to help Wagtail users build websites that have a lower climate impact.
+
+- Sustainability landing page on wagtail.org
+- Sustainability considerations documentation page in docs.wagtail.org
+- Green Web Foundation R&D and collaboration (see [Greener coding - Making a 'gold' reference configuration with the Wagtail bakery app #8843](https://github.com/wagtail/wagtail/discussions/8843))
+- Looking for sponsorships / grant funding in the sustainability space
+
+### Google Summer of Code 2023
+
+See [Google Summer of Code 2023 roadmap#31](https://github.com/wagtail/roadmap/issues/31)
+
+## Proposed provisional Wagtail 5.0 + 1 (August 2023)
+
+### Treeless page listings
+
+See [RFC 82: Treeless page listings](https://github.com/wagtail/rfcs/pull/82).
+
+### Auto-locking
+
+A preliminary step to the existing [Autosave (roadmap#24)](https://github.com/wagtail/roadmap/issues/24).
+
+### Background workers
+
+See [RFC 72: Background workers #72](https://github.com/wagtail/rfcs/pull/72)
+
+### Search improvements
+
+- Move search into separate package
+- New search back-end
+- Better docs/APIs for third-parties
+
+### RTL support
+
+See [Supporting RTL languages](https://github.com/wagtail/wagtail/discussions/7793).
+
+### Image optimisation
+
+Improvements to reduce the weight of images generated with Wagtail, that will be relevant for all sites with little to no rework.
+
+- [RFC 71: support for responsive images](https://github.com/wagtail/rfcs/blob/main/text/071-responsive-images-support.md)
+- Lossless and lossy [image optimisation operations (Willow#69)](https://github.com/wagtail/Willow/pull/69)
+- AVIF support (see [Pillow#5201](https://github.com/python-pillow/Pillow/pull/5201))
+
+### Enhanced dashboard
+
+Redesign of the dashboard so sites get more value out of it. See [The Wagtail dashboard could be enhanced #8325](https://github.com/wagtail/wagtail/discussions/8325).
+
+### Admin accessibility audit
+
+A comprehensive accessibility audit of Wagtail’s admin interface, according to our target [accessibility standards](https://wagtail.org/accessibility/), potentially also including WCAG 2.1 AAA and WCAG 2.2 A, AA, AAA criteria.
+
+See our [living accessibility audit](https://docs.google.com/spreadsheets/d/1l7tnpEyJiC5BWE_JX0XCkknyrjxYA5T2aee5JgPnmi4/edit) and [WCAG 2.1 AA for CMS admin backlog](https://github.com/wagtail/wagtail/projects/5).
+
+### Telepath everything!
+
+Extend usage of [Telepath in Wagtail](https://wagtail.org/blog/telepath/) to more of Wagtail’s forms. A preliminary step to the existing [Autosave (roadmap#24)](https://github.com/wagtail/roadmap/issues/24).
+
+## Proposed provisional Wagtail 5.0 + 2 (November 2023)
+
+### Autosave
+
+As per existing [roadmap#24](https://github.com/wagtail/roadmap/issues/24). Subsequent steps after auto-locking and more widespread usage of Telepath.
+
+### Workflow enhancements
+
+UX enhancements to [RFC 45: Workflow](https://github.com/wagtail/rfcs/blob/main/text/045-workflow.md), including modernisation of the UI and potentially introduction of more automation.
+
+### Readability checks
+
+Readability is fundamental to accessibility. One of the ways to improve text content is to have a clear target for reading level / reading age, which can be assessed with [wagtail-readinglevel](https://github.com/vixdigital/wagtail-readinglevel) as a score displayed in rich text fields.

--- a/text/084-2023-roadmap.md
+++ b/text/084-2023-roadmap.md
@@ -62,14 +62,6 @@ To keep the review process fast, we recommend to:
 
 ## Proposed items scheduled for Wagtail 5.0 (May 2023)
 
-### Permissions consolidation
-
-Consolidating our approach to permissions so code is easier to maintain.
-
-- Consistent permission model
-- Single approach for permissions (tech debt/performance as we can then introduce better caching in one place)
-- page choose permission
-
 ### Search consolidation
 
 - Fix search autocomplete
@@ -131,6 +123,14 @@ R&D and documentation programme to help Wagtail users build websites that have a
 See [Google Summer of Code 2023 roadmap#31](https://github.com/wagtail/roadmap/issues/31)
 
 ## Proposed provisional Wagtail 5.0 + 1 (August 2023)
+
+### Permissions consolidation
+
+Consolidating our approach to permissions so code is easier to maintain.
+
+- Consistent permission model
+- Single approach for permissions (tech debt/performance as we can then introduce better caching in one place)
+- page choose permission
 
 ### Treeless page listings
 

--- a/text/084-2023-roadmap.md
+++ b/text/084-2023-roadmap.md
@@ -3,7 +3,7 @@
 - RFC: 084
 - Author: Thibaud Colas
 - Created: 2023-02-27
-- Last Modified: 2023-02-27
+- Last Modified: 2023-03-15
 
 ## Abstract
 
@@ -69,7 +69,6 @@ To keep the review process fast, we recommend to:
 
 ### Snippets enhancements
 
-- Tracking deletion/unpublishing of objects used on published pages (big snippets gap)
 - Easier menu items organisation for snippets (register outside the "Snippets" menu)
 - Custom icons for snippets
 - Easier filtering setup for snippets listing
@@ -170,13 +169,17 @@ Redesign of the dashboard so sites get more value out of it. See [The Wagtail da
 
 ### Admin accessibility audit
 
-A comprehensive accessibility audit of Wagtail’s admin interface, according to our target [accessibility standards](https://wagtail.org/accessibility/), potentially also including WCAG 2.1 AAA and WCAG 2.2 A, AA, AAA criteria.
+A comprehensive accessibility audit of Wagtail’s admin interface, according to our target [accessibility standards](https://wagtail.org/accessibility/) (WCAG 2.1 AA, ATAG 2.0), potentially also including WCAG 2.1 AAA and WCAG 2.2 A, AA, AAA criteria.
 
 See our [living accessibility audit](https://docs.google.com/spreadsheets/d/1l7tnpEyJiC5BWE_JX0XCkknyrjxYA5T2aee5JgPnmi4/edit) and [WCAG 2.1 AA for CMS admin backlog](https://github.com/wagtail/wagtail/projects/5).
 
 ### Telepath everything!
 
-Extend usage of [Telepath in Wagtail](https://wagtail.org/blog/telepath/) to more of Wagtail’s forms. A preliminary step to the existing [Autosave (roadmap#24)](https://github.com/wagtail/roadmap/issues/24).
+Extend usage of [Telepath in Wagtail](https://wagtail.org/blog/telepath/) to more of Wagtail’s forms. A preliminary refactoring to the existing [Autosave (roadmap#24)](https://github.com/wagtail/roadmap/issues/24). One of the first steps will be to clarify any potential overlaps with Stimulus usage.
+
+### Snippets enhancements
+
+- Tracking deletion/unpublishing of objects used on published pages (big snippets gap)
 
 ## Proposed provisional Wagtail 5.0 + 2 (November 2023)
 


### PR DESCRIPTION
[Rendered](https://github.com/thibaudcolas/rfcs/blob/rfc-84-2023-roadmap/text/084-2023-roadmap.md)

Follow-up to #79, defining more of the roadmap process (reviewing additions via RFCs), as well as proposing specific items for the next three releases.